### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.kjumpingcube.json
+++ b/org.kde.kjumpingcube.json
@@ -6,11 +6,10 @@
     "command": "kjumpingcube",
     "rename-icon": "kjumpingcube",
     "finish-args": [
-        "--share=ipc",
-        "--socket=x11",
-        "--socket=wayland",
         "--device=dri",
-        "--filesystem=xdg-config/kdeglobals:ro"
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
     ],
     "modules": [
         {

--- a/org.kde.kjumpingcube.json
+++ b/org.kde.kjumpingcube.json
@@ -19,8 +19,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/libkdegames-23.08.5.tar.xz",
-                    "sha256": "0ac583f4327d6003782054a9ee3d51c922bcdf04577a3f7f12b3840cabf2efed",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/libkdegames-24.02.0.tar.xz",
+                    "sha256": "3d113422dc654348b2025de5fe1de256d06a3c55be9c7b104253e25595b2e2b1",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kjumpingcube-23.08.5.tar.xz",
-                    "sha256": "8deea1baf63b2cb8cb0cc10a75dd601f3bc60c970b373947459f626303d39c70",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kjumpingcube-24.02.0.tar.xz",
+                    "sha256": "a9fc0efca9b3c5d6a57febb4712f6921708922df47a9f046f085d5c793a84bbc",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/org.kde.kjumpingcube.json
+++ b/org.kde.kjumpingcube.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.kjumpingcube",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.6",
     "sdk": "org.kde.Sdk",
     "command": "kjumpingcube",
     "rename-icon": "kjumpingcube",


### PR DESCRIPTION
Update libkdegames-23.08.5.tar.xz to 24.02.0
Update kjumpingcube-23.08.5.tar.xz to 24.02.0